### PR TITLE
compiler.plugin api was removed in webpack@5

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ CompileHandlebars.prototype.apply = function(compiler) {
     let plugin = this;
     console.log("CompileHandlebars plugin is loading... " + JSON.stringify(plugin.options));
 
-    compiler.plugin('run', function(compilation, callback) {
+    compiler.hooks.done.tap('run', function(compilation, callback) {
         async.parallel(plugin.options.map(function (options) {
             return function(cb) {
                 doTask(options, cb);


### PR DESCRIPTION
https://github.com/webpack/webpack/issues/11672#issuecomment-1082353614